### PR TITLE
Export the cacheReset option to the docpad configuration

### DIFF
--- a/src/frontend.plugin.coffee
+++ b/src/frontend.plugin.coffee
@@ -131,7 +131,12 @@ module.exports = (BasePlugin) ->
 
 			getAssets = (model, prefix) ->
 				res = collectResources model, prefix
-				cacheToken = config.cacheReset or ''
+
+				if docpad.getConfig().frontendCacheReset?
+					cacheToken = docpad.getConfig().frontendCacheReset 
+				else
+					cacheToken = config.cacheReset or ''
+
 				isDebug = docpad.getConfig().frontendDebug
 				_catalog = getCatalog()
 


### PR DESCRIPTION
Add the cacheReset option to the docpad configuration. In static environments, where docpad `out` folder is being processed by a cdn, there is no nginx to create a rewrite rule. The caching of the files is set by the configuration of the CDN. 

Usage:

```
environments:
    static:
        frontendCacheReset: false
```
